### PR TITLE
fix: add backport sdl2, build and install faudio

### DIFF
--- a/wine-base/Dockerfile
+++ b/wine-base/Dockerfile
@@ -3,17 +3,28 @@ FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND="noninteractive"
 
 RUN BUILD_DEPENDENCIES="\
+  build-essential \
+  cmake \
+  git \
   software-properties-common \
   wget" \
   && dpkg --add-architecture i386 \
-  && apt-get update \
-  && apt-get install -y \
+  && apt-get update -qq && apt-get upgrade -yqq \
+  && apt-get install -yqq \
     winbind \
     $BUILD_DEPENDENCIES \
-    && wget https://dl.winehq.org/wine-builds/Release.key -O - | apt-key add - \
+    # https://forum.winehq.org/viewtopic.php?f=8&t=32061
+    && apt-add-repository ppa:cybermax-dexter/sdl2-backport \
+    && apt-get update -qq && apt-get install -yqq libsdl2-dev \
+    && git clone https://github.com/FNA-XNA/FAudio.git /tmp/faudio \
+    && mkdir -p /tmp/faudio/build && cd /tmp/faudio/build && cmake ../ \
+    && make && make install \
+    # && wget https://dl.winehq.org/wine-builds/Release.key -O - | apt-key add - \
+    # use newer key...
+    && wget https://dl.winehq.org/wine-builds/winehq.key -O - | apt-key add - \
     && apt-add-repository https://dl.winehq.org/wine-builds/ubuntu \
-    && apt-get update && apt install -y --no-install-recommends winehq-devel \
-    && apt-get remove --purge -y $BUILD_DEPENDENCIES \
-    && apt-get autoremove -y \
+    && apt-get update -qq && apt install -yqq --no-install-recommends winehq-devel \
+    && apt-get remove --purge -yqq $BUILD_DEPENDENCIES libsdl2-dev \
+    && apt-get autoremove -yqq \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes Docker Build

* adds `libsdl2` from `cybermax-dexter/sdl2-backport` PPA
* builds and installs `faudio` from https://github.com/FNA-XNA/FAudio

side effect: lots of bloat.